### PR TITLE
ex icon fix. icon component data was wrong

### DIFF
--- a/frontend/src/components/elements/IconLibrary.tsx
+++ b/frontend/src/components/elements/IconLibrary.tsx
@@ -37,8 +37,9 @@ const iconMap = new Map<IconName, (className: string) => JSX.Element>([
     ['ex', (className: string) => {
         return (
             <svg className={styles[className]} width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <title>Caret Down</title>
-                <path d="M19 8H4L11.5 15.5L19 8Z" stroke="black" />
+                <title>Ex</title>
+                <path d="M6 18L18 6" stroke="black"/>
+                <path d="M6 6L18 18" stroke="black"/>
             </svg>
         );
     }],


### PR DESCRIPTION
svg data was wrong under the "ex" icon. it was the same data used in "carretDown". Updated to use the correct SVG data for ex. KB-97 in linear